### PR TITLE
Update to work with latest orbit/ember-orbit

### DIFF
--- a/client/Brocfile.js
+++ b/client/Brocfile.js
@@ -61,24 +61,21 @@ app.import({
   production: 'vendor/showdown/compressed/showdown.js'
 });
 
-app.import({
-  development: 'vendor/orbit.js/orbit.amd.js',
-  production: 'vendor/orbit.js/orbit.amd.min.js'
+app.import('vendor/orbit.js/orbit.amd.js', {
+  exports: {'orbit': ['default']}
 });
 
-app.import({
-  development: 'vendor/orbit.js/orbit-common.amd.js',
-  production: 'vendor/orbit.js/orbit-common.amd.min.js'
+app.import('vendor/orbit.js/orbit-common.amd.js', {
+  exports: {'orbit-common': ['default']}
 });
 
-app.import({
-  development: 'vendor/orbit.js/orbit-common-jsonapi.amd.js',
-  production: 'vendor/orbit.js/orbit-common-jsonapi.amd.min.js'
+app.import('vendor/orbit.js/orbit-common-jsonapi.amd.js', {
+  exports: {'orbit-common/jsonapi-source': ['default'],
+            'orbit-common/jsonapi-serializer': ['default']}
 });
 
-app.import({
-  development: 'vendor/ember-orbit/ember-orbit.amd.js',
-  production: 'vendor/ember-orbit/ember-orbit.amd.min.js'
+app.import('vendor/ember-orbit/ember-orbit.amd.js', {
+  exports: {'ember-orbit': ['default']}
 });
 
 app.import('vendor/socket.io-client/socket.io.js');

--- a/client/app/index.html
+++ b/client/app/index.html
@@ -24,10 +24,6 @@
     <script src="assets/pixelhandler-blog.js"></script>
     <script>
       window.showdown = new Showdown.converter();
-      window.Orbit = require('orbit');
-      window.OC = require('orbit_common');
-      window.OC.JSONAPISource = require('orbit_common/jsonapi_source');
-      window.EO = require('ember_orbit');
       window.PixelhandlerBlog = require('pixelhandler-blog/app')['default'].create(PixelhandlerBlogENV.APP);
 
       if (PixelhandlerBlogENV.GOOGLE_ANALYTICS) {

--- a/client/app/initializers/ember-orbit.js
+++ b/client/app/initializers/ember-orbit.js
@@ -1,12 +1,19 @@
+import Orbit from 'orbit';
+import EO from 'ember-orbit';
+import JSONAPISource from 'orbit-common/jsonapi-source';
+
 Orbit.Promise = Ember.RSVP.Promise;
 Orbit.ajax = Ember.$.ajax;
 
+var Schema = EO.Schema.extend({
+  idField: 'id'
+});
+
 var JSONAPIStore = EO.Store.extend({
-  orbitSourceClass: OC.JSONAPISource,
+  orbitSourceClass: JSONAPISource,
   orbitSourceOptions: {
     host: PixelhandlerBlogENV.API_HOST,
-    namespace: PixelhandlerBlogENV.API_PATH,
-    idField: 'id'
+    namespace: PixelhandlerBlogENV.API_PATH
   }
 });
 
@@ -14,8 +21,7 @@ export default {
   name: 'ember-orbit',
 
   initialize: function(container, application) {
-    application.register('schema:main', EO.Schema);
-    //application.register('store:main', EO.Store);
+    application.register('schema:main', Schema);
     application.register('store:main', JSONAPIStore);
     application.inject('controller', 'store', 'store:main');
     application.inject('route', 'store', 'store:main');

--- a/client/app/models/post.js
+++ b/client/app/models/post.js
@@ -1,4 +1,4 @@
-//import EO from "ember-orbit";
+import EO from "ember-orbit";
 
 var attr = EO.attr;
 

--- a/client/app/routes/post.js
+++ b/client/app/routes/post.js
@@ -3,7 +3,7 @@ import ResetScroll from '../mixins/reset-scroll';
 
 var PostRoute = Ember.Route.extend(ResetScroll, {
   model: function (params) {
-    return this.store.find('post', params.post_id);
+    return this.store.find('post', {id: params.post_id});
     /* or with plain ajax...
     var _this = this;
     return new Ember.RSVP.Promise(function (resolve, reject) {
@@ -16,6 +16,10 @@ var PostRoute = Ember.Route.extend(ResetScroll, {
       });
     });
     */
+  },
+
+  serialize: function(model) {
+    return { post_id: model.get('slug') };
   },
 
   setupController: function (controller, model) {


### PR DESCRIPTION
- Import AMD builds to work as modules in ember-cli
- Introduce custom Schema to define `idField`
- Serialize PostRoute based on slug

TODO:
- Fix server response to `/posts/:slug` to return single post in object, not array (to conform with current JSON API spec)
