### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2014–2022 Bill Heaton
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Hi! I'm interested in using SocketSource in my own projects, but I can't do that without a suitable license.

This PR adds an MIT license to the [ember-orbit-with-socket-source](https://github.com/pixelhandler/blog/tree/ember-orbit-with-socket-source) branch, in line with the package.json files for the [client](https://github.com/pixelhandler/blog/blob/b1e39fee628b4b969cbbe1269a48a185d23e140f/client/package.json#L10) and [server](https://github.com/pixelhandler/blog/blob/b1e39fee628b4b969cbbe1269a48a185d23e140f/server/package.json#L17). (According to [this Stack Exchange answer](https://opensource.stackexchange.com/a/7244), the package.json line isn't sufficent to grant a license by itself.)

If you're happy for your code to be used, please go ahead and merge this PR, or close it and license the ember-orbit-with-socket-source branch as you see fit. 🙂 